### PR TITLE
Disable default X11 forwarding

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ sshd_rhosts_rsa_authentication: "no"
 sshd_hostbased_authentication: "no"
 sshd_permit_empty_passwords: "no"
 sshd_challenge_response_authentication: "no"
-sshd_x11_forwarding: "yes"
+sshd_x11_forwarding: "no"
 sshd_x11_display_offset: 10
 sshd_print_motd: "no"
 sshd_print_last_log: "yes"


### PR DESCRIPTION
because it is the safer default