### PR TITLE
Migrate sshd_config.j2 to Stretch version, simplify host key management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,38 +12,45 @@ The playbook requires no special configuration, but offers a bunch of options.
 
 Defaults:
 
-    # Set `sshd_port` to a list of ports to listen on.
-    sshd_port:
-      - 22
-    # Set `sshd_listen_addresses` to a list of addresses. Defaults to all IPv4+IPv6 addresses if unset.
-    #sshd_listen_address: []
-    sshd_syslog_facility: AUTH
-    sshd_log_level: INFO
-    sshd_use_privilege_seperation: "yes"
-    sshd_login_grace_time: 120
-    sshd_permit_root_login: "no"
-    sshd_strict_modes: "yes"
-    sshd_pubkey_authentication: "yes"
-    sshd_authorized_keys_file: "%h/.ssh/authorized_keys"
-    sshd_password_authentication: "no"
-    sshd_allow_users: []
-    sshd_allow_groups: []
-    sshd_ignore_rhosts: "yes"
-    sshd_hostbased_authentication: "no"
-    sshd_permit_empty_passwords: "no"
-    sshd_challenge_response_authentication: "no"
-    sshd_x11_forwarding: "no"
-    sshd_x11_display_offset: 10
-    sshd_print_motd: "no"
-    sshd_print_last_log: "yes"
-    sshd_tcp_keep_alive: "yes"
-    sshd_max_startups: "10:30:60"
-    sshd_client_alive_interval: 3600
-    sshd_client_alive_count_max: 0
-    sshd_use_pam: "yes"
-    sshd_use_dns: "no"
-    sshd_sftp_chroot: "no"
-    sshd_sftp_chroot_group: sftponly
+	# Set `sshd_port` to a list of ports to listen on.
+	sshd_port:
+	  - 22
+	
+	sshd_host_keys:
+	  - rsa
+	  - ecdsa
+	  - ed25519
+	
+	# Set `sshd_listen_address` to a list of addresses. Defaults to all
+	# IPv4+IPv6 addresses if unset.
+	#sshd_listen_address: []
+	sshd_syslog_facility: AUTH
+	sshd_log_level: INFO
+	sshd_use_privilege_seperation: "yes"
+	sshd_login_grace_time: 120
+	sshd_permit_root_login: "no"
+	sshd_strict_modes: "yes"
+	sshd_pubkey_authentication: "yes"
+	sshd_authorized_keys_file: "%h/.ssh/authorized_keys"
+	sshd_password_authentication: "no"
+	sshd_allow_users: []
+	sshd_allow_groups: []
+	sshd_ignore_rhosts: "yes"
+	sshd_hostbased_authentication: "no"
+	sshd_permit_empty_passwords: "no"
+	sshd_challenge_response_authentication: "no"
+	sshd_x11_forwarding: "no"
+	sshd_x11_display_offset: 10
+	sshd_print_motd: "no"
+	sshd_print_last_log: "yes"
+	sshd_tcp_keep_alive: "yes"
+	sshd_max_startups: "10:30:60"
+	sshd_client_alive_interval: 3600
+	sshd_client_alive_count_max: 0
+	sshd_use_pam: "yes"
+	sshd_use_dns: "no"
+	sshd_sftp_chroot: "no"
+	sshd_sftp_chroot_group: sftponly
 
 Download
 --------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,19 +3,21 @@ sshd_port:
   - 22
 
 sshd_host_keys:
-  - "/etc/ssh/ssh_host_rsa_key"
-# To enable backwards compatibility /etc/ssh/ssh_host_ed25519_key is set per default if openssh version > 6.5
+  - rsa
+  - ecdsa
+  - ed25519
 
-# Set `sshd_listen_address` to a list of addresses. Defaults to all IPv4+IPv6 addresses if unset.
+# Set `sshd_listen_address` to a list of addresses. Defaults to all
+# IPv4+IPv6 addresses if unset.
 #sshd_listen_address: []
 sshd_syslog_facility: AUTH
 sshd_log_level: INFO
-sshd_use_privilege_seperation: "yes"
-sshd_login_grace_time: 120
+sshd_use_privilege_seperation: "sandbox"
+sshd_login_grace_time: "2m"
 sshd_permit_root_login: "no"
 sshd_strict_modes: "yes"
 sshd_pubkey_authentication: "yes"
-sshd_authorized_keys_file: "%h/.ssh/authorized_keys"
+sshd_authorized_keys_file: ".ssh/authorized_keys"
 sshd_password_authentication: "no"
 sshd_allow_users: []
 sshd_allow_groups: []
@@ -28,9 +30,9 @@ sshd_x11_display_offset: 10
 sshd_print_motd: "no"
 sshd_print_last_log: "yes"
 sshd_tcp_keep_alive: "yes"
-sshd_max_startups: "10:30:60"
+sshd_max_startups: "10:30:100"
 sshd_client_alive_interval: 3600
-sshd_client_alive_count_max: 0
+sshd_client_alive_count_max: 3
 sshd_use_pam: "yes"
 sshd_use_dns: "no"
 sshd_sftp_chroot: "no"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,25 +6,12 @@
     force: yes
   notify: restart sshd
 
-- name: register openssh-server version
-  shell: 'dpkg -s openssh-server | grep "^Version" | sed -re "s/^.*:([0-9]+\.[0-9]+).*/\1/"'
-  register: openssh_version
-  check_mode: no
-  changed_when: false
-
-- name: ensure ed25519 host key is present
-  command: ssh-keygen -q -t ed25519 -N "" -f ssh_host_ed25519_key
+- name: ensure host keys are present
+  command: "ssh-keygen -q -f ssh_host_{{ item }}_key -N '' -t {{ item }}"
   args:
     chdir: /etc/ssh
-    creates: /etc/ssh/ssh_host_ed25519_key
-  when: openssh_version == true and
-        openssh_version.stdout | version_compare('6.5', '>=')
-
-- name: determine if ed25519 host key exists
-  stat:
-    path: /etc/ssh/ssh_host_ed25519_key
-  register: ed25519_key
-  check_mode: no
+    creates: "/etc/ssh/ssh_host_{{ item }}_key"
+  with_items: "{{ sshd_host_keys }}"
 
 - name: ensure openssh config is latest
   template:

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -1,93 +1,88 @@
-# Package generated configuration file
-# See the sshd_config(5) manpage for details
+#       $OpenBSD: sshd_config,v 1.100 2016/08/15 12:32:04 naddy Exp $
 
-# What ports, IPs and protocols we listen for
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
 {% if sshd_port|d() %}
 {%   for port in sshd_port %}
 Port {{ port }}
 {%   endfor %}
+{% else %}
+#Port 22
 {% endif %}
-# Use these options to restrict which interfaces/protocols sshd will bind to
+#AddressFamily any
 {% if sshd_listen_address|d() %}
 {%   for address in sshd_listen_address %}
 ListenAddress {{ address }}
 {%   endfor %}
+{% else %}
+#ListenAddress 0.0.0.0
+#ListenAddress ::
 {% endif %}
-Protocol 2
-# HostKeys for protocol version 2
+
 {% for key in sshd_host_keys %}
-HostKey {{ key }}
+HostKey /etc/ssh/ssh_host_{{ key }}_key
 {% endfor %}
-{% if ed25519_key|default(False) and ed25519_key.stat.exists %}
-HostKey /etc/ssh/ssh_host_ed25519_key
-{% endif%}
-#Privilege Separation is turned on for security
-UsePrivilegeSeparation {{ sshd_use_privilege_seperation }}
+
+# Ciphers and keying
+#RekeyLimit default none
 
 # Logging
 SyslogFacility {{ sshd_syslog_facility }}
 LogLevel {{ sshd_log_level }}
 
 # Authentication:
+
 LoginGraceTime {{ sshd_login_grace_time }}
 PermitRootLogin {{ sshd_permit_root_login }}
 StrictModes {{ sshd_strict_modes }}
+#MaxAuthTries 6
+#MaxSessions 10
 
 PubkeyAuthentication {{ sshd_pubkey_authentication }}
+
+# Expect .ssh/authorized_keys2 to be disregarded by default in future.
 AuthorizedKeysFile {{ sshd_authorized_keys_file }}
 
-{% if sshd_allow_users %}
-AllowUsers {{ sshd_allow_users|join(" ") }}
-{% endif %}
+#AuthorizedPrincipalsFile none
 
-{% if sshd_allow_groups %}
-AllowGroups {{ sshd_allow_groups|join(" ") }}
-{% endif %}
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
 
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+HostbasedAuthentication {{ sshd_hostbased_authentication }}
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts {{ sshd_ignore_rhosts }}
 
-# similar for protocol version 2
-HostbasedAuthentication {{ sshd_hostbased_authentication }}
-# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
-#IgnoreUserKnownHosts yes
-
-# To enable empty passwords, change to yes (NOT RECOMMENDED)
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication {{ sshd_password_authentication }}
 PermitEmptyPasswords {{ sshd_permit_empty_passwords }}
 
 # Change to yes to enable challenge-response passwords (beware issues with
 # some PAM modules and threads)
 ChallengeResponseAuthentication {{ sshd_challenge_response_authentication }}
 
-# Change to no to disable tunnelled clear text passwords
-PasswordAuthentication {{ sshd_password_authentication }}
-
 # Kerberos options
 #KerberosAuthentication no
-#KerberosGetAFSToken no
 #KerberosOrLocalPasswd yes
 #KerberosTicketCleanup yes
+#KerberosGetAFSToken no
 
 # GSSAPI options
 #GSSAPIAuthentication no
 #GSSAPICleanupCredentials yes
-
-X11Forwarding {{ sshd_x11_forwarding }}
-X11DisplayOffset {{ sshd_x11_display_offset }}
-PrintMotd {{ sshd_print_motd }}
-PrintLastLog {{ sshd_print_last_log }}
-TCPKeepAlive {{ sshd_tcp_keep_alive }}
-#UseLogin no
-
-MaxStartups {{ sshd_max_startups }}
-
-#Banner /etc/issue.net
-
-# Allow client to pass locale environment variables
-AcceptEnv LANG LC_*
-
-ClientAliveInterval {{ sshd_client_alive_interval }}
-ClientAliveCountMax {{ sshd_client_alive_count_max }}
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
 
 # Set this to 'yes' to enable PAM authentication, account processing,
 # and session processing. If this is enabled, PAM authentication will
@@ -100,9 +95,44 @@ ClientAliveCountMax {{ sshd_client_alive_count_max }}
 # and ChallengeResponseAuthentication to 'no'.
 UsePAM {{ sshd_use_pam }}
 
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding {{ sshd_x11_forwarding }}
+X11DisplayOffset {{ sshd_x11_display_offset }}
+#X11UseLocalhost yes
+#PermitTTY yes
+PrintMotd {{ sshd_print_motd }}
+PrintLastLog {{ sshd_print_last_log }}
+TCPKeepAlive {{ sshd_tcp_keep_alive }}
+#UseLogin no
+UsePrivilegeSeparation {{ sshd_use_privilege_seperation }}
+#PermitUserEnvironment no
+#Compression delayed
+ClientAliveInterval {{ sshd_client_alive_interval }}
+ClientAliveCountMax {{ sshd_client_alive_count_max }}
 UseDNS {{ sshd_use_dns }}
+#PidFile /var/run/sshd.pid
+MaxStartups {{ sshd_max_startups }}
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
 
-Subsystem sftp internal-sftp
+# no default banner path
+#Banner none
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+# override default of no subsystems
+Subsystem       sftp    internal-sftp
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#       X11Forwarding no
+#       AllowTcpForwarding no
+#       PermitTTY no
+#       ForceCommand cvs server
 
 {% if sshd_sftp_chroot == 'yes' %}
 Match Group {{ sshd_sftp_chroot_group }}
@@ -111,8 +141,14 @@ Match Group {{ sshd_sftp_chroot_group }}
         AllowTcpForwarding no
 {% endif %}
 
+{% if sshd_allow_users|d() %}
+AllowUsers {{ sshd_allow_users|join(" ") }}
+{% endif %}
+
+{% if sshd_allow_groups|d() %}
+AllowGroups {{ sshd_allow_groups|join(" ") }}
+{% endif %}
+
 # Specifies whether to remove an existing Unix-domain socket file for
 # local or remote port forwarding before creating a new one.
 StreamLocalBindUnlink {{ sshd_stream_local_bind_unlink }}
-
-


### PR DESCRIPTION
* Migrate the sshd_config.j2 template to the latest version from Debian
  Stretch
* Install host keys of type rsa, ecdsa and ed25519 per default
* Don't check for SSHd version before installing ed25519 key, we don't
  support Debian Wheezy any longer.