### PR TITLE
[sshd] - fix broken sshd_config on version < 6.7

### DIFF
--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -149,6 +149,8 @@ AllowUsers {{ sshd_allow_users|join(" ") }}
 AllowGroups {{ sshd_allow_groups|join(" ") }}
 {% endif %}
 
+{% if ansible_distribution == 'Debian' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('14.04', '>' )) %}
 # Specifies whether to remove an existing Unix-domain socket file for
 # local or remote port forwarding before creating a new one.
 StreamLocalBindUnlink {{ sshd_stream_local_bind_unlink }}
+{% endif %}


### PR DESCRIPTION
- Fixes the following problem: if StreamLocalBindUnlink is inserted in < version 6.7 (Ubuntu 14.04) ssh will restart, but refuses any connections

- so StreamLocalBindUnlink will only be deployed on Debian and on Ubuntu if ansible_distribution_version > 14.04